### PR TITLE
Mention scheme-index.aartaka.me

### DIFF
--- a/scheme-index-app/src/index.html
+++ b/scheme-index-app/src/index.html
@@ -15,6 +15,8 @@
 </head>
 <body>
   <app-root></app-root>
-  <noscript>Please enable JavaScript to continue using this application.</noscript>
+  <noscript>Please enable JavaScript to continue using this application.
+  Otherwise, use <a href="https://scheme-index.aartaka.me">Artyom Bologov’s version of the index</a>.
+  </noscript>
 </body>
 </html>


### PR DESCRIPTION
This is a version that focuses on being fully static and HTML+CSS-only. This fills the gap that index.scheme.org left with the (rude) noscript forbidding no-JS view.