### PR TITLE
Fix the typo generating non-?-suffixed predicates for numeric vecs

### DIFF
--- a/types/srfi.160.REST_PLACEHOLDER.scm
+++ b/types/srfi.160.REST_PLACEHOLDER.scm
@@ -308,6 +308,6 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-@vector")
  (signature
    case-lambda
-   (((@vector @vec)) undefined)
-   (((@vector @vec) (output-port? port)) undefined))
+   (((@vector? @vec)) undefined)
+   (((@vector? @vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of @vec in the lexical syntax explained below."))

--- a/types/srfi.160.c128.scm
+++ b/types/srfi.160.c128.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-c128vector")
  (signature
    case-lambda
-   (((c128vector c128vec)) undefined)
-   (((c128vector c128vec) (output-port? port)) undefined))
+   (((c128vector? c128vec)) undefined)
+   (((c128vector? c128vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of c128vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.c64.scm
+++ b/types/srfi.160.c64.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-c64vector")
  (signature
    case-lambda
-   (((c64vector c64vec)) undefined)
-   (((c64vector c64vec) (output-port? port)) undefined))
+   (((c64vector? c64vec)) undefined)
+   (((c64vector? c64vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of c64vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.f32.scm
+++ b/types/srfi.160.f32.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-f32vector")
  (signature
    case-lambda
-   (((f32vector f32vec)) undefined)
-   (((f32vector f32vec) (output-port? port)) undefined))
+   (((f32vector? f32vec)) undefined)
+   (((f32vector? f32vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of f32vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.f64.scm
+++ b/types/srfi.160.f64.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-f64vector")
  (signature
    case-lambda
-   (((f64vector f64vec)) undefined)
-   (((f64vector f64vec) (output-port? port)) undefined))
+   (((f64vector? f64vec)) undefined)
+   (((f64vector? f64vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of f64vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.s16.scm
+++ b/types/srfi.160.s16.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-s16vector")
  (signature
    case-lambda
-   (((s16vector s16vec)) undefined)
-   (((s16vector s16vec) (output-port? port)) undefined))
+   (((s16vector? s16vec)) undefined)
+   (((s16vector? s16vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of s16vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.s32.scm
+++ b/types/srfi.160.s32.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-s32vector")
  (signature
    case-lambda
-   (((s32vector s32vec)) undefined)
-   (((s32vector s32vec) (output-port? port)) undefined))
+   (((s32vector? s32vec)) undefined)
+   (((s32vector? s32vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of s32vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.s64.scm
+++ b/types/srfi.160.s64.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-s64vector")
  (signature
    case-lambda
-   (((s64vector s64vec)) undefined)
-   (((s64vector s64vec) (output-port? port)) undefined))
+   (((s64vector? s64vec)) undefined)
+   (((s64vector? s64vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of s64vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.s8.scm
+++ b/types/srfi.160.s8.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-s8vector")
  (signature
    case-lambda
-   (((s8vector s8vec)) undefined)
-   (((s8vector s8vec) (output-port? port)) undefined))
+   (((s8vector? s8vec)) undefined)
+   (((s8vector? s8vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of s8vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.u16.scm
+++ b/types/srfi.160.u16.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-u16vector")
  (signature
    case-lambda
-   (((u16vector u16vec)) undefined)
-   (((u16vector u16vec) (output-port? port)) undefined))
+   (((u16vector? u16vec)) undefined)
+   (((u16vector? u16vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of u16vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.u32.scm
+++ b/types/srfi.160.u32.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-u32vector")
  (signature
    case-lambda
-   (((u32vector u32vec)) undefined)
-   (((u32vector u32vec) (output-port? port)) undefined))
+   (((u32vector? u32vec)) undefined)
+   (((u32vector? u32vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of u32vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.u64.scm
+++ b/types/srfi.160.u64.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-u64vector")
  (signature
    case-lambda
-   (((u64vector u64vec)) undefined)
-   (((u64vector u64vec) (output-port? port)) undefined))
+   (((u64vector? u64vec)) undefined)
+   (((u64vector? u64vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of u64vec in the lexical syntax explained below."))
 )

--- a/types/srfi.160.u8.scm
+++ b/types/srfi.160.u8.scm
@@ -353,7 +353,7 @@ When multiple vectors are passed, pred? must take the same number of arguments a
 ((name . "write-u8vector")
  (signature
    case-lambda
-   (((u8vector u8vec)) undefined)
-   (((u8vector u8vec) (output-port? port)) undefined))
+   (((u8vector? u8vec)) undefined)
+   (((u8vector? u8vec) (output-port? port)) undefined))
  (desc . "Prints to port (the current output port by default) a representation of u8vec in the lexical syntax explained below."))
 )


### PR DESCRIPTION
In #63, I listed some types I scraped from the files. Some were weird, like non-predicate `s16vector` et al. So I digged in and found that all numeric vector files had a typo—missing a question mark in `write-@vector` signature.

Here’s a fix.